### PR TITLE
Allow CiviCRM database to be different than the CMS one during civi.setup.ini

### DIFF
--- a/plugins/init/Backdrop.civi-setup.php
+++ b/plugins/init/Backdrop.civi-setup.php
@@ -39,12 +39,16 @@ if (!defined('CIVI_SETUP')) {
 
     // Compute DSN.
     global $databases;
-    $model->db = $model->cmsDb = array(
+    $model->cmsDb = array(
       'server' => \Civi\Setup\DbUtil::encodeHostPort($databases['default']['default']['host'], $databases['default']['default']['port'] ?: NULL),
       'username' => $databases['default']['default']['username'],
       'password' => $databases['default']['default']['password'],
       'database' => $databases['default']['default']['database'],
     );
+
+    if(empty($model->db)) {
+      $model->db = $model->cmsDb;
+    }
 
     // Compute URLs
     global $base_url, $base_path;

--- a/plugins/init/Drupal.civi-setup.php
+++ b/plugins/init/Drupal.civi-setup.php
@@ -37,12 +37,16 @@ if (!defined('CIVI_SETUP')) {
 
     // Compute DSN.
     global $databases;
-    $model->db = $model->cmsDb = array(
+    $model->cmsDb = array(
       'server' => \Civi\Setup\DbUtil::encodeHostPort($databases['default']['default']['host'], $databases['default']['default']['port'] ?: NULL),
       'username' => $databases['default']['default']['username'],
       'password' => $databases['default']['default']['password'],
       'database' => $databases['default']['default']['database'],
     );
+
+    if(empty($model->db)) {
+      $model->db = $model->cmsDb;
+    }
 
     // Compute cmsBaseUrl.
     global $base_url, $base_path;

--- a/plugins/init/Drupal8.civi-setup.php
+++ b/plugins/init/Drupal8.civi-setup.php
@@ -36,12 +36,16 @@ if (!defined('CIVI_SETUP')) {
 
       // Compute DSN.
       $databases = \Drupal\Core\Database\Database::getConnectionInfo();
-      $model->db = $model->cmsDb = array(
+      $model->cmsDb = array(
         'server' => \Civi\Setup\DbUtil::encodeHostPort($databases['default']['host'], $databases['default']['port'] ?: NULL),
         'username' => $databases['default']['username'],
         'password' => $databases['default']['password'],
         'database' => $databases['default']['database'],
       );
+
+      if(empty($model->db)) {
+        $model->db = $model->cmsDb;
+      }
 
       // Compute cmsBaseUrl.
       global $base_url, $base_path;

--- a/plugins/init/WordPress.civi-setup.php
+++ b/plugins/init/WordPress.civi-setup.php
@@ -50,12 +50,16 @@ if (!defined('CIVI_SETUP')) {
     $model->templateCompilePath = implode(DIRECTORY_SEPARATOR, [$uploadDir['basedir'], 'civicrm', 'templates_c']);
 
     // Compute DSN.
-    $model->db = $model->cmsDb = array(
+    $model->cmsDb = array(
       'server' => DB_HOST,
       'username' => DB_USER,
       'password' => DB_PASSWORD,
       'database' => DB_NAME,
     );
+
+    if(empty($model->db)) {
+      $model->db = $model->cmsDb;
+    }
 
     // Compute URLs
     $model->cmsBaseUrl = site_url();


### PR DESCRIPTION
### Problem

Any DB configuration passed to the model via the `\Civi\Setup::init()` method was ignored and CiviCRM ended up installed in the CMS database.

### Solution

The problem was caused because the plugins listening to the `civi.setup.init` event, which is triggered when you call `\Civi\Setup::init()`, would override any value passed to the db param with the cms db configuration.

To avoid that, the db configuration is only set to the same one as the cmsDb if no db configuration is specified (i.e. `$model->db` is empty).