### PR TITLE
Use utf8mb4 encoding to support 4-byte characters

### DIFF
--- a/src/Setup/DbUtil.php
+++ b/src/Setup/DbUtil.php
@@ -104,7 +104,7 @@ class DbUtil {
   public static function sourceSQL($db, $SQLcontent, $lineMode = FALSE) {
     $conn = self::connect($db);
 
-    $conn->query('SET NAMES utf8');
+    $conn->query('SET NAMES utf8mb4');
 
     if (!$lineMode) {
       $string = $SQLcontent;

--- a/src/Setup/DbUtil.php
+++ b/src/Setup/DbUtil.php
@@ -104,7 +104,7 @@ class DbUtil {
   public static function sourceSQL($db, $SQLcontent, $lineMode = FALSE) {
     $conn = self::connect($db);
 
-    $conn->query('SET NAMES utf8mb4');
+    $conn->query('SET NAMES ' . ($conn->server_version < 50503 ? 'utf8' : 'utf8mb4'));
 
     if (!$lineMode) {
       $string = $SQLcontent;


### PR DESCRIPTION
CiviCRM doesn't actually use utf8mb4 yet, but we can start using utf8mb4 for purposes of future-proofing / best practices.

Note: This would require MySQL 5.5.3+ and I'm not sure what minimum MySQL version this library needs to support.